### PR TITLE
Feature/supp mentions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ snakejob.*
 *.sqlite
 
 listings/
+dist

--- a/setup.py
+++ b/setup.py
@@ -11,12 +11,12 @@ TEST_REQS = ['biopython', 'snakemake', 'ftputil', 'requests', 'pytest', 'pytest-
 
 setup(
     name='bioconverters',
-    version='1.0.0',
+    version='1.0.1',
     packages=['bioconverters'],
     package_dir={'': 'src'},
     description='Convert between NCBI pubmed/PMC and BIOC formats',
     long_description=long_description,
-    long_description_format='md',
+    long_description_content_type='text/markdown',
     install_requires=['bioc >=1.3, <2', 'typing_extensions'],
     extras_require={'dev': DEV_REQS + TEST_REQS, 'test': TEST_REQS},
     python_requires='>=3.6',

--- a/src/bioconverters/utils.py
+++ b/src/bioconverters/utils.py
@@ -237,10 +237,17 @@ def tag_handler(
             else:
                 return [TextChunk(head, elem, is_annotation=True)]
     elif elem.tag in IGNORE_LIST:
-        # Check if the tag should be ignored (so don't use main contents)
-        return [
-            TextChunk(tail, elem, non_separating=True, is_tail=True),
-        ]
+        if not all(
+            [
+                elem.tag == 'ext-link',
+                head,
+                re.search(r'(supp|suppl|supplementary)?\s*(table|figure)\s*s?\d+', head.lower()),
+            ]
+        ):
+            # Check if the tag should be ignored (so don't use main contents)
+            return [
+                TextChunk(tail, elem, non_separating=True, is_tail=True),
+            ]
 
     return [TextChunk(head, elem)] + child_passages + [TextChunk(tail, elem, is_tail=True)]
 


### PR DESCRIPTION
v1.0.1 Release

BugFixes
- #7 Keep content of ext-link tags when they are references to supplementary material
- Fix content_type tag error in setup.py

closes #7 