### PR TITLE
Bugfix/mark citations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     name: python-${{ matrix.python-version }}
     steps:
     - uses: actions/checkout@v2

--- a/src/bioconverters/pmcxml.py
+++ b/src/bioconverters/pmcxml.py
@@ -373,7 +373,6 @@ def pmcxml2bioc(
     all_xml_path_infon: bool = False,
     mark_citations: bool = False,
 ) -> Iterator[Iterable[bioc.BioCDocument]]:
-    assert not mark_citations, "Currently mark_citations is disabled due to documented issue: https://github.com/jakelever/biotext/issues/9"
     """
     Convert a PMC XML file into its Bioc equivalent
 
@@ -443,7 +442,13 @@ def pmcxml2bioc(
 
                     for annotation in passage.annotations:
                         for location in annotation.locations:
-                            assert location.offset >= passage.offset and (location.offset+location.length < passage.offset+len(passage.text)), f"location.offset={location.offset} and passage.offset={passage.offset}"
+                            if location.offset < passage.offset or (
+                                location.offset + location.length
+                                >= passage.offset + len(passage.text)
+                            ):
+                                raise AssertionError(
+                                    f"annotation.id={annotation.id} location.offset={location.offset} and passage.offset={passage.offset}"
+                                )
 
                     offset += len(text_source)
                     bioc_doc.add_passage(passage)

--- a/src/bioconverters/utils.py
+++ b/src/bioconverters/utils.py
@@ -319,7 +319,8 @@ def strip_annotation_markers(
         transformed_text = transformed_text[: start - offset] + transformed_text[end - offset :]
 
         # since the token place-holder is removed, must be start - 1 (and previous offset) for the new position
-        ann.add_location(bioc.BioCLocation(start - offset - 1, 0))
+        annotation_offset = max(start - offset - 1, 0)  # if annotation is the first thing in a passage it may have a -1 start, should reset to 0
+        ann.add_location(bioc.BioCLocation(annotation_offset, 0))
 
         offset += end - start
         transformed_annotations.append(ann)

--- a/tests/test_pmcxml.py
+++ b/tests/test_pmcxml.py
@@ -2,7 +2,7 @@ from io import StringIO
 
 import bioc
 import pytest
-import requests
+
 from bioconverters.main import docs2bioc
 from bioconverters.utils import TABLE_DELIMITER, TextChunk
 
@@ -18,6 +18,12 @@ def table_article():
 @pytest.fixture(scope='module')
 def formula_article():
     article = fetch_xml('PMC2939780', 'pmc')
+    return article
+
+
+@pytest.fixture(scope='module')
+def citation_offset_article():
+    article = fetch_xml('PMC8466798', 'pmc')
     return article
 
 
@@ -50,13 +56,13 @@ def test_custom_tag_handler(table_article):
 
     assert any([expected_content in p.text for p in all_passages])
 
-@pytest.mark.skip(reason="Test is currently disabled as mark_citations issue (#9) is unresolved")
+
 def test_sibling_intext_citations(table_article):
     all_passages = []
     all_annotations = []
     file = StringIO(table_article)
 
-    for doc in docs2bioc(file, 'pmcxml', trim_sentences=False):
+    for doc in docs2bioc(file, 'pmcxml', trim_sentences=False, mark_citations=True):
         all_passages.extend(doc.passages)
         all_annotations.extend(bioc.annotations(doc))
 
@@ -68,3 +74,9 @@ def test_sibling_intext_citations(table_article):
         ['inspected using the graphics program PyMOL.' in chunk.text for chunk in all_passages]
     )
     assert '[14],[16],[23]\u2013[25]' in [a.infons['citation_text'] for a in all_annotations]
+
+
+def test_citation_offset(citation_offset_article):
+    # https://github.com/jakelever/biotext/issues/9
+    file = StringIO(citation_offset_article)
+    list(docs2bioc(file, 'pmcxml', trim_sentences=False, mark_citations=True))

--- a/tests/test_pmcxml.py
+++ b/tests/test_pmcxml.py
@@ -64,10 +64,9 @@ def test_sibling_intext_citations(table_article):
 
     for doc in docs2bioc(file, 'pmcxml', trim_sentences=False, mark_citations=True):
         all_passages.extend(doc.passages)
-        all_annotations.extend(bioc.annotations(doc))
+        all_annotations.extend([a.annotation for a in bioc.annotations(doc)])
 
     for chunk in all_passages:
-        print(chunk.text)
         if 'PyMOL' in chunk.text:
             break
     assert any(


### PR DESCRIPTION
BugFIxes:
- #9 

Removes support in tests for python 3.6 and adds python 3.11 due to GitHub Actions no longer supporting python 3.6