### PR TITLE
Update pmcxml.py; PubMedCentral IDs in EuropePMC JATS files are known…

### DIFF
--- a/src/bioconverters/pmcxml.py
+++ b/src/bioconverters/pmcxml.py
@@ -180,7 +180,7 @@ def get_meta_info_for_pmc_article(
     for a in article_id:
         if a.text and "pub-id-type" in a.attrib and a.attrib["pub-id-type"] == "pmid":
             pmid_text = a.text.strip().replace("\n", " ")
-        if a.text and "pub-id-type" in a.attrib and a.attrib["pub-id-type"] == "pmc":
+        if a.text and "pub-id-type" in a.attrib and a.attrib["pub-id-type"] == "pmcid":
             pmcid_text = a.text.strip().replace("\n", " ")
         if a.text and "pub-id-type" in a.attrib and a.attrib["pub-id-type"] == "doi":
             doi_text = a.text.strip().replace("\n", " ")


### PR DESCRIPTION
… as "pmcid" and not "pmc"; otherwise no PMC ID is retrieved from publications